### PR TITLE
feat(apps/reflect): Disable user's login provider button

### DIFF
--- a/apps/reflect/src/components/auth/LinkAccount.tsx
+++ b/apps/reflect/src/components/auth/LinkAccount.tsx
@@ -8,12 +8,19 @@ import {
 import GitHubIcon from "@mui/icons-material/GitHub";
 import { SiDiscord, SiTwitch } from "react-icons/si";
 import { signIn } from "next-auth/react";
+import { trpc } from "../../utils/trpc";
+import React, { useEffect, useState } from "react";
+import { capitalizeWord } from "../../utils/functions";
 
 const LinkAccount = () => {
+  const accounts = trpc.security.getAccounts.useQuery();
+  const currentProviders = accounts.data?.map(account => account.provider);
+
   return (
     <>
       <ListItem
         button
+        disabled={currentProviders?.includes("discord")}
         onClick={() => signIn("discord")}
         sx={{ "&:hover": { borderRadius: 1 } }}>
         <ListItemAvatar>
@@ -25,6 +32,7 @@ const LinkAccount = () => {
       </ListItem>
       <ListItem
         button
+        disabled={currentProviders?.includes("github")}
         onClick={() => signIn("github")}
         sx={{ "&:hover": { borderRadius: 1 } }}>
         <ListItemAvatar>
@@ -36,6 +44,7 @@ const LinkAccount = () => {
       </ListItem>
       <ListItem
         button
+        disabled={currentProviders?.includes("twitch")}
         onClick={() => signIn("twitch")}
         sx={{ "&:hover": { borderRadius: 1 } }}>
         <ListItemAvatar>

--- a/apps/reflect/src/components/auth/LinkAccount.tsx
+++ b/apps/reflect/src/components/auth/LinkAccount.tsx
@@ -9,8 +9,6 @@ import GitHubIcon from "@mui/icons-material/GitHub";
 import { SiDiscord, SiTwitch } from "react-icons/si";
 import { signIn } from "next-auth/react";
 import { trpc } from "../../utils/trpc";
-import React, { useEffect, useState } from "react";
-import { capitalizeWord } from "../../utils/functions";
 
 const LinkAccount = () => {
   const accounts = trpc.security.getAccounts.useQuery();


### PR DESCRIPTION
To prevent the user from clicking on the login providers again via settings/security and to address this issue, the provider buttons that the user logged in with have been disabled

note: The GitHub and Twitch logins have not been verified. Please test them and make sure they are working correctly.


https://user-images.githubusercontent.com/88425310/230798545-1d5c65ad-537a-4098-98e5-93a4206e5d48.mov

