### PR TITLE
fix(apps/reflect): Snackbar is not working

### DIFF
--- a/apps/reflect/src/components/app/AppSnackbar.tsx
+++ b/apps/reflect/src/components/app/AppSnackbar.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Snackbar, { SnackbarOrigin } from "@mui/material/Snackbar";
-import { Slide, SlideProps } from "@mui/material";
+import { Alert, Slide, SlideProps } from "@mui/material";
+import { FC } from "react";
+import { SneacbarSeverity } from "../../enums";
 
 type TransitionProps = Omit<SlideProps, "direction">;
 
@@ -8,14 +10,19 @@ function TransitionUp(props: TransitionProps) {
   return <Slide {...props} direction="up" />;
 }
 
-const AppSnackbar = ({
-  isSnackbarOpen,
-  snackbarMessage,
-}: {
+type IProps = {
   isSnackbarOpen: boolean;
   snackbarMessage: string;
+  snackbarClose: () => void;
+  severity: SneacbarSeverity;
+};
+
+const AppSnackbar: FC<IProps> = ({
+  isSnackbarOpen,
+  snackbarMessage,
+  snackbarClose,
+  severity,
 }) => {
-  const [open, setOpen] = React.useState(false);
   const [transition, setTransition] = React.useState<
     React.ComponentType<TransitionProps> | undefined
   >(undefined);
@@ -24,17 +31,15 @@ const AppSnackbar = ({
     setTransition(() => TransitionUp);
   }, [isSnackbarOpen]);
 
-  const handleClose = () => {};
-
   return (
     <Snackbar
-      open={open}
-      onClose={handleClose}
+      open={isSnackbarOpen}
+      onClose={snackbarClose}
       TransitionComponent={transition}
-      autoHideDuration={3200}
-      message={snackbarMessage}
-      key={transition ? transition.name : ""}
-    />
+      autoHideDuration={6000}
+      key={transition ? transition.name : ""}>
+      <Alert severity={severity}>{snackbarMessage}</Alert>
+    </Snackbar>
   );
 };
 

--- a/apps/reflect/src/enums/index.ts
+++ b/apps/reflect/src/enums/index.ts
@@ -1,0 +1,4 @@
+export enum SneacbarSeverity {
+  Info = "info",
+  Success = "success",
+}


### PR DESCRIPTION
This PR fixes an issue with `snackbar` not working properly. Additionally, it adds two new variants, `info` and `success`, to the `SnackbarSeverity` enum to customize the Snackbar.

## Changes Made

- Fixed issue with `snackbar` not working properly
- Added `info` and `success` variants to `SnackbarSeverity` enum