### PR TITLE
fix(apps/reflect): langingText responsive

### DIFF
--- a/apps/reflect/src/components/landing/LandingTexts.tsx
+++ b/apps/reflect/src/components/landing/LandingTexts.tsx
@@ -99,7 +99,7 @@ const LandingTexts = () => {
       <Stack
         direction="column"
         textAlign="center"
-        width={{ xs: "100vw", md: "37vw" }}>
+        width={{ xs: "100vw", sm: "75vw", lg: "37vw" }}>
         <Typography
           variant="h1"
           component="div"


### PR DESCRIPTION
in This PR fixed responsive design `landingText`


![Screenshot 2023-05-07 at 19 10 28](https://user-images.githubusercontent.com/88425310/236689190-00c6ea38-04fc-44c2-b806-23d858d92076.png)
