### PR TITLE
fix: rename config table key and value columns

### DIFF
--- a/apps/reflect/prisma/schema.prisma
+++ b/apps/reflect/prisma/schema.prisma
@@ -96,8 +96,8 @@ model TwitchChannel {
 
 model TwitchBotConfigs {
     id              Int      @id @default(autoincrement())
-    key             String   @map("key")
-    value           String   @map("value")
+    key             String   @map("config_key")
+    value           String   @map("config_value")
     twitchChannelId String   @map("twitch_channel_id")
     userId          String?  @map("user_id")
     user            User?    @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/apps/twitch-bot/internal/backend/postgresql/postgresql.go
+++ b/apps/twitch-bot/internal/backend/postgresql/postgresql.go
@@ -57,7 +57,7 @@ func (b *PostgreSQLBackend) CreateTwitchChannel(ctx context.Context, channelId s
 
 func (b *PostgreSQLBackend) GetTwitchBotConfig(ctx context.Context, twitchChannelId string, configKey string) (*models.TwitchBotConfig, error) {
 	var twitchBotConfig models.TwitchBotConfig
-	result := b.DB.Where("twitch_channel_id = ?", twitchChannelId).Where("key = ?", configKey).First(&twitchBotConfig)
+	result := b.DB.Where("twitch_channel_id = ?", twitchChannelId).Where("config_key = ?", configKey).First(&twitchBotConfig)
 
 	if result.Error != nil {
 		return nil, errors.New("(GetTwitchBotConfig) db.First Error:" + result.Error.Error())

--- a/apps/twitch-bot/internal/models/models.go
+++ b/apps/twitch-bot/internal/models/models.go
@@ -11,8 +11,8 @@ type TwitchChannel struct {
 
 type TwitchBotConfig struct {
 	ID              int
-	Key             string `gorm:"column:key"`
-	Value           string `gorm:"column:value"`
+	Key             string `gorm:"column:config_key"`
+	Value           string `gorm:"column:config_value"`
 	TwitchChannelID string `gorm:"column:twitch_channel_id"`
 }
 


### PR DESCRIPTION
Necessary because MySQL in production reserves the `key` keyword.