### PR TITLE
fix(apps/twitch-bot): add check to prevent the same name from being used when creating aliases

### DIFF
--- a/apps/twitch-bot/internal/backend/postgresql/postgresql.go
+++ b/apps/twitch-bot/internal/backend/postgresql/postgresql.go
@@ -222,6 +222,11 @@ func (b *PostgreSQLBackend) CreateCommandAliases(ctx context.Context, commandNam
 			return &infoText, nil
 		}
 
+		if commandAlias == commandName {
+			infoText = "you cannot use the same name in command and command alias"
+			return &infoText, nil
+		}
+
 		commandAlias := models.BotCommandAlias{
 			CommandAlias:    commandAlias,
 			CommandName:     commandName,


### PR DESCRIPTION
Add check to prevent using the same name in both the command and the command alias