### PR TITLE
Fix discord event channel ids array

### DIFF
--- a/apps/discord-bot/config.ts
+++ b/apps/discord-bot/config.ts
@@ -1,2 +1,2 @@
 // Discord Channel Ids string[]
-export const TWITCH_EVENTS_CHANNELS = [];
+export const TWITCH_EVENTS_CHANNELS = [""];


### PR DESCRIPTION
```
utils/scheduledEventFunctions.ts(16,40): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
```