### PR TITLE
feat: ensure db:generate is always run before build and dev

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^db:generate"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"],
       "env": [
         "VERCEL_URL", "PORT", "NODE_ENV"
@@ -16,6 +16,7 @@
       "outputs": []
     },
     "dev": {
+      "dependsOn": ["^db:generate"],
       "cache": false
     },
     "start": {


### PR DESCRIPTION
* Update turbo.json to be more efficient.
* Add db:generate to build and dev scripts in turbo.json.

This ensures that db:generate is always run before dev and build, so that new developers will not get errors.