### PR TITLE
fix(apps/twitch-bot): add a temporary fix to the character length of …

### DIFF
--- a/apps/twitch-bot/internal/command/cmds.go
+++ b/apps/twitch-bot/internal/command/cmds.go
@@ -24,5 +24,14 @@ func (c *commands) CmdsCommand(context context.Context, message twitch.PrivateMe
 
 	commandListString = strings.Join(commandListArr, ", ")
 
+	if len(commandListString) > 300 {
+		first := commandListString[:300]
+		c.client.Twitch.Say(message.Channel, message.Channel+"'s Channel Commands: "+first)
+
+		second := commandListString[300:]
+		c.client.Twitch.Say(message.Channel, second)
+		return
+	}
+
 	c.client.Twitch.Say(message.Channel, message.Channel+"'s Channel Commands: "+commandListString)
 }


### PR DESCRIPTION
…the cmds command response

This had to be done because the character length of the cmds command response was getting blocked by the Twitch message character limit and the bot was not responding. will be changed when the command listing page is brought to the web app.